### PR TITLE
Fix IP String Formatting in static_routing: kernel_route_on_table

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/static_routing/test_kernel_route.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/static_routing/test_kernel_route.py
@@ -41,6 +41,7 @@ async def test_alpha_lab_static_routing_kernel_route_on_table(testbed):
     dent_dev = dent_devices[0]
     dent = dent_dev.host_name
     swp = 'ma1'
+    swp_num = int(''.join([c for c in swp if c.isdigit()]))
 
     await IpLink.show(
         input_data=[{dent: [{'device': swp, 'cmd_options': '-j'}]}],
@@ -48,7 +49,7 @@ async def test_alpha_lab_static_routing_kernel_route_on_table(testbed):
 
     swp_info = {}
     await tgen_utils_get_swp_info(dent_dev, swp, swp_info)
-    sip = '.'.join(swp_info['ip'][:-1] + [str(int(swp[3:]) * 2)])
+    sip = '.'.join(swp_info['ip'][:-1] + [str(swp_num * 2)])
 
     # start from a clean state
     await IpRoute.add(


### PR DESCRIPTION
- `static_routing: kernel_route_on_table:` generate valid int from net device string

#### Log Before Fix:

`swp` is declared as `'ma1'`, which has 3 characters, so `swp[3:]` is empty.

```
>       sip = '.'.join(swp_info['ip'][:-1] + [str(int(swp[3:]) * 2)])
E       ValueError: invalid literal for int() with base 10: ''
```

#### Log After Fix

```
Passed | alpha/static_routing/test_kernel_route.py::test_alpha_lab_static_routing_kernel_route_on_table | 230.71
```


